### PR TITLE
Update index.html.template, added a missing '/'

### DIFF
--- a/index.html.template
+++ b/index.html.template
@@ -16,7 +16,7 @@ found in the LICENSE file. -->
   <nav>
     <ul>
       <li><a href="https://v8.dev/tools">Tools</a></li>
-      <li class="current"><a href="https:/v8.dev/tools/versions">Tools Versions</a></li>
+      <li class="current"><a href="https://v8.dev/tools/versions">Tools Versions</a></li>
       <li><a href="https://v8.dev">Main Page</a></li>
     </ul>
   </nav>


### PR DESCRIPTION
The "Tools Versions" tab's href is missing a "/" when you are on the "Tools Versions" page.

ik almost no one will notice this because why are you pressing the same button twice, but might as well fix it now that I did.  